### PR TITLE
feature/import path

### DIFF
--- a/docs/components/ImportPath.js
+++ b/docs/components/ImportPath.js
@@ -37,7 +37,12 @@ class InputWithButton extends React.Component {
                     {this.props.path}
                     <i className="fa fa-copy" aria-hidden="true"></i>
                 </code>
-                <span aria-hidden="true" style={this.state.copied ? {transition: "opacity 1s", opacity: 1} : {opacity: 0}}>Copied</span>
+                <span aria-hidden="true" 
+                    style={this.state.copied ? 
+                        {transition: "visibility 0s, opacity 0.5s", visibility: "visible", opacity: 1} : 
+                        {opacity: 0, visibility: "hidden"}}>
+                        Copied
+                    </span>
             </div>
         );
     }

--- a/docs/components/ImportPath.js
+++ b/docs/components/ImportPath.js
@@ -30,8 +30,10 @@ class InputWithButton extends React.Component {
 
     render(){
         return (
-            <div className="dxb-importpath" onMouseLeave={this.resetTooltipText}>
-                <code ref={(input) => this.textInput = input} onClick={this.copyToClipboard} >
+            <div className="dxb-importpath" >
+                <code ref={(input) => this.textInput = input} 
+                    onClick={this.copyToClipboard}
+                    onMouseLeave={this.resetTooltipText} >
                     {this.props.path}
                     <i className="fa fa-copy" aria-hidden="true"></i>
                 </code>

--- a/docs/components/ImportPath.scss
+++ b/docs/components/ImportPath.scss
@@ -10,7 +10,11 @@
         &:hover {
             color: grey;
             cursor: pointer;
-        }   
+        } 
+        
+        &:hover > i {
+            visibility: visible;
+        }  
     }
     // tooltip
     span {
@@ -50,9 +54,5 @@
         margin-left: 3px;
         color: black;
         padding: 5px;
-    }
-
-    &:hover > code > i {
-        visibility: visible;
     }
 }


### PR DESCRIPTION
Two small fixes:
- Fix css so that import path hover does not get activated when mouse is hovering over the invisible tooltip.
- Set onMouseLeave callback on code block, instead of outer div.