### PR TITLE
Fix theme paths

### DIFF
--- a/docs/content/concepts/Css.js
+++ b/docs/content/concepts/Css.js
@@ -158,13 +158,13 @@ export const CssPage = <cx>
             <CodeSnippet lang="scss">{`
             // here you have a chance to override Cx variables
 
-            @import "~cx/variables"; 
+            @import "~cx-core/src/variables"; 
 
             // you can override state-style-maps here, before importing CSS
 
             //$cx-include-global-rules: false; //include global rules (reset)
             //$cx-include-all: true; //include CSS for all components
-            @import "~cx/index";
+            @import "~cx-core/src/index";
 
             //if $cx-include-all is set to false
             //@include cx-textfield(); //include only the components you need

--- a/docs/content/concepts/Css.js
+++ b/docs/content/concepts/Css.js
@@ -158,13 +158,13 @@ export const CssPage = <cx>
             <CodeSnippet lang="scss">{`
             // here you have a chance to override Cx variables
 
-            @import "~cx-core/variables"; 
+            @import "~cx/variables"; 
 
             // you can override state-style-maps here, before importing CSS
 
             //$cx-include-global-rules: false; //include global rules (reset)
             //$cx-include-all: true; //include CSS for all components
-            @import "~cx-core/index";
+            @import "~cx/index";
 
             //if $cx-include-all is set to false
             //@include cx-textfield(); //include only the components you need
@@ -185,9 +185,9 @@ export const CssPage = <cx>
         <CodeSplit>
             <CodeSnippet lang="scss">{`
             ...
-            @import "~cx-theme-dark/variables";
+            @import "~cx-theme-dark/src/variables";
             ...
-            @import "~cx-theme-dark/index";
+            @import "~cx-theme-dark/src/index";
             ...
             `}</CodeSnippet>
         </CodeSplit>
@@ -197,7 +197,7 @@ export const CssPage = <cx>
 
         <CodeSplit>
             <CodeSnippet lang="scss">{`
-                import "cx-theme-frost";
+                import "cx-theme-frost/src";
             `}</CodeSnippet>
         </CodeSplit>
 


### PR DESCRIPTION
Import paths for themes should be OK now.
Important to note: 
* when using the neutral theme, index.scss and variables.scss are imported from the cx-core/src folder whose webpack alias is 'cx', so the correct import path is ~cx/variables and ~cx/index
* on the other hand, webpack aliases for theme packages do not include the 'src' folder, so it needs to be appended to the import path, e.g. @import '~cx-theme-frost/src/variables'