### PR TITLE
Selected list item background color changed 

### DIFF
--- a/packages/cx-core/src/variables.scss
+++ b/packages/cx-core/src/variables.scss
@@ -109,10 +109,10 @@ $cx-list-item: (
       outline: none,
    ),
    selected: (
-      background-color: rgba(128, 128, 128, 0.2),
+      background-color: rgba(123,190,255, 0.2),
    ),
    selected-focus: (
-      background-color: rgba(123,190,255, 0.4),
+      background-color: rgba(123,190,255, 0.45),
       outline: none
    ),
    active: (


### PR DESCRIPTION
When not focused, a background color of selected list item was gray. Now it's light blue in neutral theme.